### PR TITLE
fix: move eslint-plugin-jest to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@commitlint/config-conventional": "^7.5.0",
     "eslint": "^5.16.0",
     "eslint-find-rules": "^3.3.1",
-    "eslint-plugin-jest": "^22.4.1",
     "husky": "^1.3.1",
     "is-ci-cli": "^1.1.1",
     "lint-staged": "^8.1.5",
@@ -48,7 +47,8 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-import": "^2.17.2"
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-jest": "^22.4.1"
   },
   "scripts": {
     "test": "npm-run-all --parallel find-new-rules:*",


### PR DESCRIPTION
Resolves the plugin not being accessible to the end user without them installing it manually.