### PR TITLE
fix: use babel plugin to allow experimental features

### DIFF
--- a/best-practices.js
+++ b/best-practices.js
@@ -35,7 +35,7 @@ module.exports = {
     'no-implicit-coercion': 'error',
     'no-implicit-globals': 'error',
     'no-implied-eval': 'error',
-    'no-invalid-this': 'error', // Confirm sourceType module
+    'no-invalid-this': 'error',
     'no-iterator': 'error',
     'no-labels': 'error',
     'no-lone-blocks': 'error',

--- a/es6.js
+++ b/es6.js
@@ -7,6 +7,7 @@ module.exports = {
     ecmaVersion: 2019,
     sourceType: 'module',
   },
+  plugins: ['babel'],
   rules: {
     'constructor-super': 'error',
     'no-class-assign': 'error',
@@ -37,5 +38,29 @@ module.exports = {
     'require-yield': 'error',
     'sort-imports': 'off',
     'symbol-description': 'error',
+
+    /* Babel plugin options to eliminate false positives
+     * for experimental features
+     */
+    'new-cap': 'off',
+    'babel/new-cap': [
+      'error',
+      {
+        newIsCap: true,
+        capIsNew: true,
+        properties: true,
+      },
+    ],
+    'no-invalid-this': 'off',
+    'babel/no-invalid-this': 'error',
+    'valid-typeof': 'off',
+    'babel/valid-typeof': 'error',
+
+    // Unused babel plugin rules
+    'babel/camelcase': 'off',
+    'babel/no-unused-expressions': 'off',
+    'babel/object-curly-spacing': 'off',
+    'babel/semi': 'off',
+    'babel/quotes': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-jest": "^22.4.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,13 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-babel@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz#2e7f251ccc249326da760c1a4c948a91c32d0023"
+  integrity sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-plugin-import@^2.17.2:
   version "2.17.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"
@@ -974,6 +981,11 @@ eslint-plugin-jest@^22.4.1:
   version "22.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz#a5fd6f7a2a41388d16f527073b778013c5189a9c"
   integrity sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-rule-documentation@^1.0.0:
   version "1.0.22"


### PR DESCRIPTION
Resolves issue with false positives from standard ESLint rules when using Experimental features in Babel.