### PR TITLE
fix: update import order

### DIFF
--- a/import.js
+++ b/import.js
@@ -67,8 +67,7 @@ module.exports = {
         groups: [
           'builtin',
           ['external', 'internal'],
-          ['parent', 'sibling'],
-          'index',
+          ['parent', 'sibling', 'index'],
         ],
         'newlines-between': 'always-and-inside-groups',
       },


### PR DESCRIPTION
Removes index files from their own grouping to reduce unnecessary spacing. Config still allows for spacing within groups if desired.