### PR TITLE
fix: update duplicate imports standard rule

### DIFF
--- a/import.js
+++ b/import.js
@@ -26,6 +26,9 @@ module.exports = {
     'import/no-cycle': 'error',
     'import/no-default-export': 'off',
     'import/no-deprecated': 'off',
+
+    // Favor import variant which supports Flow type imports
+    'no-duplicate-imports': 'off',
     'import/no-duplicates': 'error',
     'import/no-dynamic-require': 'off',
     'import/no-extraneous-dependencies': [


### PR DESCRIPTION
Turn off standard rule in favor of import variant.
Default variant causes issues with Flow imports.