### PR TITLE
feat(rules): update eslint-plugin-jest to 22.5.1

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -19,6 +19,7 @@ module.exports = {
     'jest/no-jasmine-globals': 'warn',
     'jest/no-jest-import': 'error',
     'jest/no-large-snapshots': ['warn', { maxSize: 300 }],
+    'jest/no-mocks-import': 'error',
     'jest/no-test-callback': 'off',
     'jest/no-test-prefixes': 'off',
     'jest/no-test-return-statement': 'warn',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,9 +1015,9 @@ eslint-plugin-import@^2.17.2:
     resolve "^1.10.0"
 
 eslint-plugin-jest@^22.4.1:
-  version "22.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz#a5fd6f7a2a41388d16f527073b778013c5189a9c"
-  integrity sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==
+  version "22.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.5.1.tgz#a31dfe9f9513c6af7c17ece4c65535a1370f060b"
+  integrity sha512-c3WjZR/HBoi4GedJRwo2OGHa8Pzo1EbSVwQ2HFzJ+4t2OoYM7Alx646EH/aaxZ+9eGcPiq0FT0UGkRuFFx2FHg==
 
 eslint-plugin-jsx-a11y@^6.2.1:
   version "6.2.1"


### PR DESCRIPTION
Resolves #24.

BREAKING CHANGE: Adds the no-mocks-import rule. May result in new
linting errors.